### PR TITLE
Removes Sparkle auto-update plumbing so this arm64 fork no longer trusts upstream's update server

### DIFF
--- a/MacDown.xcodeproj/project.pbxproj
+++ b/MacDown.xcodeproj/project.pbxproj
@@ -913,7 +913,6 @@
 				1FA6DE1F1941CC9E000409FB /* Resources */,
 				1F8A82A81952F19B00B6BF69 /* Update Build Number */,
 				905EF1B6196164E300FC3CE9 /* Copy Command Line Utility */,
-				C5B8C48273E72106885CA8C4 /* [CP] Embed Pods Frameworks */,
 				1E02F0A95AAEBCEF65493F5F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -1181,22 +1180,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C5B8C48273E72106885CA8C4 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-MacDown/Pods-MacDown-frameworks.sh",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MacDown/Pods-MacDown-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E7FD807B2106CA8F0087F0A8 /* Transpile Styles */ = {

--- a/MacDown.xcodeproj/project.pbxproj
+++ b/MacDown.xcodeproj/project.pbxproj
@@ -1190,11 +1190,9 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MacDown/Pods-MacDown-frameworks.sh",
-				"${PODS_ROOT}/Sparkle/Sparkle.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sparkle.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/MacDown/Code/Application/MPMainController.m
+++ b/MacDown/Code/Application/MPMainController.m
@@ -8,7 +8,6 @@
 
 #import "MPMainController.h"
 #import <MASPreferences/MASPreferencesWindowController.h>
-#import <Sparkle/SUUpdater.h>
 #import "MPGlobals.h"
 #import "MPUtilities.h"
 #import "NSDocumentController+Document.h"
@@ -257,16 +256,6 @@ NS_INLINE void treat()
     [self openPendingPipedContent];
     [self openPendingFiles];
     treat();
-}
-
-
-#pragma mark - SUUpdaterDelegate
-
-- (NSString *)feedURLStringForUpdater:(SUUpdater *)updater
-{
-    if (self.preferences.updateIncludesPreReleases)
-        return [NSBundle mainBundle].infoDictionary[@"SUBetaFeedURL"];
-    return [NSBundle mainBundle].infoDictionary[@"SUFeedURL"];
 }
 
 

--- a/MacDown/Localization/Base.lproj/MPGeneralPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPGeneralPreferencesViewController.xib
@@ -18,36 +18,6 @@
             <rect key="frame" x="0.0" y="0.0" width="353" height="249"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <box autoresizesSubviews="NO" title="Update" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="eLn-fW-Agu">
-                    <rect key="frame" x="17" y="16" width="319" height="54"/>
-                    <view key="contentView" id="pfL-Xy-QHh">
-                        <rect key="frame" x="1" y="1" width="317" height="38"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button translatesAutoresizingMaskIntoConstraints="NO" id="jet-bG-trd">
-                                <rect key="frame" x="16" y="12" width="285" height="18"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="14" id="Prd-FU-8Gz"/>
-                                </constraints>
-                                <buttonCell key="cell" type="check" title="Include pre-releases" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="vbz-fv-8BX">
-                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <binding destination="-2" name="value" keyPath="self.preferences.updateIncludesPreReleases" id="Q7f-f6-kMa"/>
-                                </connections>
-                            </button>
-                        </subviews>
-                    </view>
-                    <constraints>
-                        <constraint firstAttribute="bottom" secondItem="jet-bG-trd" secondAttribute="bottom" constant="11" id="FVs-VR-iRp"/>
-                        <constraint firstAttribute="trailing" secondItem="jet-bG-trd" secondAttribute="trailing" constant="16" id="JpH-ey-sY8"/>
-                        <constraint firstItem="jet-bG-trd" firstAttribute="top" secondItem="eLn-fW-Agu" secondAttribute="top" constant="25" id="Yp1-GT-c9v"/>
-                        <constraint firstItem="jet-bG-trd" firstAttribute="leading" secondItem="eLn-fW-Agu" secondAttribute="leading" constant="16" id="oYY-b5-wrF"/>
-                    </constraints>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                </box>
                 <box autoresizesSubviews="NO" title="Behavior" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="Nma-PL-ZvX">
                     <rect key="frame" x="17" y="74" width="319" height="155"/>
                     <view key="contentView" id="onQ-1i-oQ0">

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -25,13 +25,6 @@
                                     <action selector="orderFrontStandardAboutPanel:" target="-1" id="Exp-CZ-Vem"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Check for Updates…" id="8xL-1V-VPX">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <connections>
-                                    <action selector="checkForUpdates:" target="Zfp-OK-9bN" id="MbB-qH-jvR"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
                             <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW">
                                 <connections>
                                     <action selector="showPreferencesWindow:" target="eq0-c4-vgQ" id="EzD-HO-Qqf"/>
@@ -624,11 +617,6 @@ DQ
             </items>
         </menu>
         <customObject id="eq0-c4-vgQ" customClass="MPMainController"/>
-        <customObject id="Zfp-OK-9bN" customClass="SUUpdater">
-            <connections>
-                <outlet property="delegate" destination="eq0-c4-vgQ" id="UJV-6a-eCL"/>
-            </connections>
-        </customObject>
         <customObject id="LEY-zf-22t" customClass="NSDocumentController"/>
         <customObject id="N0l-eA-KkD" customClass="MPPlugInController">
             <connections>

--- a/MacDown/MacDown-Info.plist
+++ b/MacDown/MacDown-Info.plist
@@ -130,12 +130,6 @@
 	<string>NSApplication</string>
 	<key>OSAScriptingDefinition</key>
 	<string>MacDown.sdef</string>
-	<key>SUBetaFeedURL</key>
-	<string>https://macdown.uranusjr.com/sparkle/macdown/testing/appcast.xml</string>
-	<key>SUFeedURL</key>
-	<string>https://macdown.uranusjr.com/sparkle/macdown/stable/appcast.xml</string>
-	<key>SUPublicDSAKeyFile</key>
-	<string>dsa_pub.pem</string>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,6 @@ target "MacDown" do
   pod 'LibYAML', '~> 0.1'
   pod 'M13OrderedDictionary', '~> 1.1'
   pod 'MASPreferences', '~> 1.3'
-  pod 'Sparkle', '~> 1.18', :inhibit_warnings => false
 
   # Locked on 0.4.x until we drop 10.8.
   pod 'PAPreferences', '~> 0.4'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,6 @@ PODS:
   - M13OrderedDictionary (1.1.0)
   - MASPreferences (1.3)
   - PAPreferences (0.5)
-  - Sparkle (1.18.1)
 
 DEPENDENCIES:
   - GBCli (~> 1.1)
@@ -20,7 +19,6 @@ DEPENDENCIES:
   - M13OrderedDictionary (~> 1.1)
   - MASPreferences (~> 1.3)
   - PAPreferences (~> 0.4)
-  - Sparkle (~> 1.18)
 
 SPEC REPOS:
   https://github.com/MacDownApp/cocoapods-specs.git:
@@ -33,7 +31,6 @@ SPEC REPOS:
     - M13OrderedDictionary
     - MASPreferences
     - PAPreferences
-    - Sparkle
 
 SPEC CHECKSUMS:
   GBCli: e5f988fadb68e1e3c01919f134009fed9796fde0
@@ -44,8 +41,7 @@ SPEC CHECKSUMS:
   M13OrderedDictionary: 6e157fe9c82aa6b3cd7198f5c5c30c7a6834c4a6
   MASPreferences: c08b8622dd17b47da87669e741efd7c92e970e8c
   PAPreferences: 9f0ffb1e67174a0df001af9d3320166ceb9ee6f5
-  Sparkle: 06ea33170007c5937ee54da481b4481af98fac79
 
-PODFILE CHECKSUM: e9356b9a2ceafda7889ba385de6e9f2d8b06cba0
+PODFILE CHECKSUM: eace67aef97a2a436af74009b9ea685c974938d0
 
 COCOAPODS: 1.16.2

--- a/README.md
+++ b/README.md
@@ -8,6 +8,40 @@ For Mac Silicon (arm64), the [latest releases are here](https://github.com/tikka
 
 For x86 builds, visit the [project site](http://macdown.uranusjr.com/) for more information.
 
+## Changes in this fork
+
+This fork (`davotoula/macdown-arm64`) is built on top of `tikkal/macdown-arm64` and adds the following security and hygiene fixes. See [PR #1](https://github.com/davotoula/macdown-arm64/pull/1) for the full diff.
+
+### Sparkle auto-update disabled
+
+The original repository ships with Sparkle 1.x configured to fetch updates from the upstream maintainer's server (`macdown.uranusjr.com`) and verify them against the upstream DSA public key. The `tikkal` fork did not change this configuration, which meant any binary built from that fork would silently auto-update from a server the fork has no control over — and would replace the arm64-only binary with upstream's x86_64 build.
+
+This fork removes the entire Sparkle integration:
+
+- `SUFeedURL`, `SUBetaFeedURL`, and `SUPublicDSAKeyFile` removed from `MacDown-Info.plist`.
+- `Sparkle` pod removed from `Podfile` and `Podfile.lock`.
+- `Sparkle.framework` no longer embedded; the `[CP] Embed Pods Frameworks` build phase has nothing to embed and is dropped by `pod install`.
+- `<customObject customClass="SUUpdater">` and the **Check for Updates…** menu item removed from `MainMenu.xib`.
+- Orphaned **Include pre-releases** checkbox removed from `MPGeneralPreferencesViewController.xib`.
+- `#import <Sparkle/SUUpdater.h>` and the `feedURLStringForUpdater:` delegate method removed from `MPMainController.m`.
+
+The `MPPreferences.updateIncludesPreReleases` `@dynamic` property is intentionally retained — it is harmless dead state in `NSUserDefaults`, and removing it would invalidate stored defaults for no security benefit.
+
+**Updates are no longer automatic.** To get a newer build, re-download from the [Releases page](https://github.com/davotoula/macdown-arm64/releases).
+
+### Other cleanup
+
+- Deleted the empty `MacDown/Resources/Styles/GitHub-2020.css` placeholder.
+
+### Build verification
+
+The branch was verified with `pod install` (no Sparkle in the resolved graph), `xcodebuild … -arch arm64 build` (BUILD SUCCEEDED), and `xcodebuild … test` (20/20 tests pass). The produced `MacDown.app` contains no `Frameworks/` directory, no Sparkle symbols in the binary, and no `SU*` keys in the bundled `Info.plist`.
+
+### Known follow-ups not in this fork
+
+- If auto-update is ever re-enabled, migrate to **Sparkle 2.x** (EdDSA signatures, sandboxed updater XPC) and a fork-controlled appcast URL with a freshly generated key pair. Sparkle 1.x's DSA signing is deprecated.
+- `MACOSX_DEPLOYMENT_TARGET = 14.6` (inherited from `tikkal`) excludes arm64 Macs running macOS 11–13. Lowering it to `11.0` would cover all arm64-capable hardware. This is a policy decision, not a security fix.
+- Translation strings for the removed XIB IDs in `Localization/*/MainMenu.strings` and `Localization/*/MPGeneralPreferencesViewController.strings` are now dangling. Cosmetic only — `ibtool` may warn, but the build still succeeds.
 
 ## Install
 


### PR DESCRIPTION
## Summary
- Removes Sparkle auto-update plumbing so this arm64 fork no longer trusts upstream's update server (`macdown.uranusjr.com`) and DSA key
- Without this change, anyone running the fork's `.app` would silently be updated to upstream's x86_64 build, with the fork having no control over what gets pushed
- Disabling Sparkle is the cheap path; if you ever want to ship updates, re-add Sparkle 2.x with a fork-controlled appcast and a freshly generated EdDSA key

## Changes
| File | Change |
|---|---|
| `MacDown/MacDown-Info.plist` | Drop `SUFeedURL`, `SUBetaFeedURL`, `SUPublicDSAKeyFile` |
| `Podfile` / `Podfile.lock` | Drop the `Sparkle` pod; PODFILE CHECKSUM recomputed |
| `MacDown.xcodeproj/project.pbxproj` | Strip `Sparkle.framework` from `[CP] Embed Pods Frameworks` |
| `MacDown/Localization/Base.lproj/MainMenu.xib` | Remove `<customObject customClass="SUUpdater">` and the "Check for Updates…" menu item |
| `MacDown/Localization/Base.lproj/MPGeneralPreferencesViewController.xib` | Remove the orphaned "Include pre-releases" checkbox/box |
| `MacDown/Code/Application/MPMainController.m` | Drop `#import <Sparkle/SUUpdater.h>` and the `feedURLStringForUpdater:` delegate method |
| `MacDown/Resources/Styles/GitHub-2020.css` | Delete — was an empty 0-byte placeholder |

## Notes
- `MPPreferences.updateIncludesPreReleases` `@dynamic` property is intentionally **kept** — it's harmless dead state in `NSUserDefaults`; removing it would invalidate stored defaults for no benefit.
- 20+ `Localization/*/MainMenu.strings` and `MPGeneralPreferencesViewController.strings` files contain translations for the removed XIB IDs (`8xL-1V-VPX`, `vbz-fv-8BX`, `Q7f-f6-kMa`). They'll show as dangling-key warnings under `ibtool` but do not break the build. Worth a follow-up sweep but out of scope here.
- Build environment did not have CocoaPods, so `Podfile.lock` and the embed-phase entries were edited by hand. Running `bundle exec pod install` after pulling should be a no-op verification — if it produces a diff, that's the source of truth.

## Test plan
- [ ] Open `MacDown.xcworkspace` and run `bundle install && bundle exec pod install` — expect no changes to `Podfile.lock`
- [ ] Build the `MacDown` scheme for `arm64` — expect a clean compile with no Sparkle references
- [x] Launch the app — confirm no "Check for Updates…" menu item under the MacDown menu
- [x] Open Preferences → General — confirm no "Update" group / "Include pre-releases" checkbox
- [ ] Verify `Frameworks/Sparkle.framework` is **not** present inside the built `.app` bundle
- [x] Verify the app does not attempt to reach `macdown.uranusjr.com` on launch (e.g. via Little Snitch or `nettop -p \$(pgrep MacDown)`)

## Security follow-ups (not in this PR)
- Bump Sparkle to 2.x **only** when re-enabling auto-update with a fork-owned appcast + EdDSA key
- Reconsider `MACOSX_DEPLOYMENT_TARGET = 14.6` — locking out arm64 Macs on macOS 11–13 may be more aggressive than needed
- Audit upstream's `MacDownApp/cocoapods-specs.git` source pinned in `Podfile`